### PR TITLE
feature: improve status reporting

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -30,6 +30,7 @@ describe('Plugin', () => {
     },
     signalk: new EventEmitter(),
     selfId,
+    setPluginStatus: (s: string) => console.log(s),
   }
 
   before(async () => {


### PR DESCRIPTION
Use InfluxDb success and error callbacks to keep track of successful and failed writes and report the status of all Influxes on the server dashboard.