### PR TITLE
feature: use data type from signalk-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "prettier -w src/",
     "lint": "eslint -c .eslintrc.js --ext .ts --ext .js --fix src/",
     "format": "npm run prettier && npm run lint",
-    "ci-lint": "eslint -c .eslintrc.js --ext .ts --ext .js src/ && prettier --check src/",    
+    "ci-lint": "eslint -c .eslintrc.js --ext .ts --ext .js src/ && prettier --check src/",
     "generate-schema": "./generate-schema >dist/PluginConfig.json",
     "build": "tsc && npm run generate-schema",
     "prepublishOnly": "npm install && npm run build"
@@ -47,6 +47,7 @@
     "@influxdata/influxdb-client-apis": "^1.29.0",
     "@js-joda/core": "^5.3.0",
     "@js-joda/timezone": "^2.12.1",
+    "@signalk/signalk-schema": "^1.6.0",
     "s2-geometry": "^1.2.10"
   }
 }

--- a/src/signalk__signalk-schema/index.d.ts
+++ b/src/signalk__signalk-schema/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@signalk/signalk-schema'


### PR DESCRIPTION
Use @signalk/signalk-schema.getUnits to derive data type in InfluxDb: if the schema has unit for the path and the unit is not a timestamp force numeric data type in Influxdb.

This will prevent value type related errors where the first value that is written to Influx has a bogus data type and all subsequent values just create errors because the type that ended in Influx is off.

Fixes #7.