### PR TITLE
fix: add sort to retrieving track data

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -117,6 +117,7 @@ async function getValues(
     |> aggregateWindow(every: ${timeResolutionMillis.toFixed(0)}ms, fn: first)
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
     |> keep(columns: ["_time", "lat", "lon"])
+    |> sort(columns:["_time"])
     `
   }
   debug(query)


### PR DESCRIPTION
Apparently influx needs an explicit sort here, otherwise the data may be out of order, in blocks.