### PR TITLE
refactor: rewrite queries with InfluxQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@js-joda/core": "^5.3.0",
     "@js-joda/timezone": "^2.12.1",
     "@signalk/signalk-schema": "^1.6.0",
+    "influx": "^5.9.3",
     "s2-geometry": "^1.2.10"
   },
   "peerDependencies": {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,39 @@
+import { ZonedDateTime } from '@js-joda/core'
+import { getValues } from './HistoryAPI'
+import { SKInflux } from './influx'
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+/* eslint-disable  @typescript-eslint/no-unused-vars */
+
+const toConsole = (s: any) => console.log(s)
+const logging = {
+  debug: toConsole,
+  error: toConsole,
+}
+
+const skinflux = new SKInflux(
+  {
+    onlySelf: true,
+    url: process.env.URL || '!!!',
+    token: process.env.TOKEN || '!!!',
+    bucket: process.env.BUCKET || '!!!',
+    org: process.env.ORG || '!!!',
+    writeOptions: {},
+  },
+  logging,
+  () => undefined,
+)
+const context = process.env.CONTEXT || 'no-context'
+const start = ZonedDateTime.parse('2023-07-24T13:03:29.048Z')
+const end = ZonedDateTime.parse('2023-07-24T13:04:29.048Z')
+const req = {
+  query: {
+    paths: process.env.PATHS,
+    resolution: '60s',
+  },
+}
+const resp = {
+  status: (n: number) => undefined,
+  json: (s: any) => console.log(JSON.stringify(s, null, 2)),
+}
+getValues(skinflux, context, start, end, toConsole, req, resp)


### PR DESCRIPTION
I first started to implement query by series, to support different aggregates (min, max) per paths, but switched to doing everything in InfluxQL instead because of way better performance. Flux performed abysmally.

InfluxQL queries now use InfluxV2's V1 api, with the v1 client library.