### PR TITLE
Export navigation.position data in gpx format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ Discussion in [Signal K Slack](https://signalk-dev.slack.com/) ([get invited](ht
 The plugin implements the Signal K History API, allowing retrieval of historical data with urls like
 - http://localhost:3000/signalk/v1/history/values?from=2023-04-23T18:51:26Z&to=2023-04-23T19:58:43Z&paths=environment.wind.angleApparent:min
 - http://localhost:3000/signalk/v1/history/values?from=2023-04-23T18:53:20Z&to=2023-04-23T18:55:00Z&paths=environment.wind.angleApparent:min,navigation.speedOverGround:max&resolution=40
+
+.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,3 @@ Discussion in [Signal K Slack](https://signalk-dev.slack.com/) ([get invited](ht
 The plugin implements the Signal K History API, allowing retrieval of historical data with urls like
 - http://localhost:3000/signalk/v1/history/values?from=2023-04-23T18:51:26Z&to=2023-04-23T19:58:43Z&paths=environment.wind.angleApparent:min
 - http://localhost:3000/signalk/v1/history/values?from=2023-04-23T18:53:20Z&to=2023-04-23T18:55:00Z&paths=environment.wind.angleApparent:min,navigation.speedOverGround:max&resolution=40
-
-.

--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -124,7 +124,7 @@ function getPositions(
       outputPositionsJson(rows, context, from, to, res)
     } else {
       // requested format not supported, return error with list of supported formats
-      outputError(res, '400', 'Format \'' + format + '\' is not supported. Supported formats are: ' + supportedFormats + '.')
+      outputError(res, 400, 'Format \'' + format + '\' is not supported. Supported formats are: ' + supportedFormats + '.')
     }
   })
 }
@@ -396,10 +396,10 @@ function outputPositionsJson(rows: any[], context: string, from: ZonedDateTime, 
   })
 }
 
-function outputError(res: Response, status: string, detail: string) {
-  res.status(400)
+function outputError(res: Response, status: number, detail: string) {
+  res.status(status)
   res.json({
-    status: status,
+    status: status.toString(),
     detail: detail
   })
 }

--- a/src/query.ts
+++ b/src/query.ts
@@ -28,14 +28,15 @@ const skinflux = new SKInflux(
 const context = process.env.CONTEXT || 'no-context'
 const start = ZonedDateTime.parse('2023-07-24T13:03:29.048Z')
 const end = ZonedDateTime.parse('2023-07-24T13:04:29.048Z')
+const format = ''
 const req = {
   query: {
     paths: process.env.PATHS,
     resolution: '60s',
   },
 }
-const resp = {
-  status: (n: number) => undefined,
-  json: (s: any) => console.log(JSON.stringify(s, null, 2)),
-}
-getValues(skinflux, context, start, end, toConsole, req, resp)
+// const resp = {
+//   status: (n: number) => undefined,
+//   json: (s: any) => console.log(JSON.stringify(s, null, 2)),
+// }
+//getValues(skinflux, context, start, end, format, toConsole, req, resp)


### PR DESCRIPTION
The output of navigation.position data can be formatted as gpx if the request specifies the parameter 'format' with value 'gpx'.