### PR TITLE
feature: add option to use Signal K data timestamps

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -387,8 +387,8 @@ function outputPositionsGpx(rows: any[], context: string, res: SimpleResponse) {
   res.send(responseBody)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function outputPositionsJson(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rows: any[],
   context: string,
   from: ZonedDateTime,

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -62,6 +62,7 @@ describe('Plugin', () => {
           },
           ignoredPaths: [],
           ignoredSources: [],
+          useSKTimestamp: false,
         },
       ],
     })

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -93,7 +93,7 @@ export default function InfluxPluginFactory(app: App): Plugin & InfluxPlugin {
               update.values &&
                 update.values.forEach((pathValue) => {
                   skInfluxes.forEach((skInflux) =>
-                    skInflux.handleValue(delta.context, isSelf, update.$source, pathValue),
+                    skInflux.handleValue(delta.context, isSelf, update.$source, update.timestamp, pathValue),
                   )
                 })
             })

--- a/src/query.ts
+++ b/src/query.ts
@@ -21,6 +21,7 @@ const skinflux = new SKInflux(
     writeOptions: {},
     ignoredPaths: [],
     ignoredSources: [],
+    useSKTimestamp: false,
   },
   logging,
   () => undefined,


### PR DESCRIPTION
Add the ability to use the timestamp in the incoming
SK data so that you can play back older data and get
it written to the db with correct timestamps.

Fixes #42.