### PR TITLE
fix: writeApi options not working

### DIFF
--- a/src/influx.ts
+++ b/src/influx.ts
@@ -141,6 +141,7 @@ export class SKInflux {
     this.useSKTimestamp = useSKTimestamp
     this.resolution = resolution
     this.writeApi = this.influx.getWriteApi(org, bucket, 'ms', {
+      ...config.writeOptions,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       writeFailed: (_error, lines, _attempt, _expires) => {
         this.failedLinesCount += lines.length


### PR DESCRIPTION
WriteApi options like batchsize were not being passed to Influx client and they were not taking effect. This fixes the issue.

Fixes #57.