### PR TITLE
fix: multiple dashboard status messages

### DIFF
--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -326,7 +326,7 @@ describe('Plugin', () => {
           new Promise<ValuesResponse>((resolve) => {
             const to = ZonedDateTime.now(ZoneId.UTC)
             getValues(
-              plugin.skInfluxes[0],
+              plugin.skInfluxes()[0],
               TESTCONTEXT as Context,
               from,
               to,


### PR DESCRIPTION
Every save of plugin configuration would create
an additional entry in the dashboard message.