### PR TITLE
feature: add filteringrules

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -111,7 +111,7 @@ interface SimpleRequest {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ValuesResultRow = any[]
 
-function getPositions(
+export function getPositions(
   v1Client: InfluxV1,
   context: string,
   from: ZonedDateTime,

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -63,6 +63,7 @@ describe('Plugin', () => {
             flushInterval: 10,
             maxRetries: 1,
           },
+          filteringRules: [],
           ignoredPaths: [],
           ignoredSources: [],
           useSKTimestamp: false,
@@ -255,6 +256,7 @@ describe('Plugin', () => {
             flushInterval: 10,
             maxRetries: 1,
           },
+          filteringRules: [],
           ignoredPaths: [],
           ignoredSources: [],
           useSKTimestamp: true, // <===============

--- a/src/query.ts
+++ b/src/query.ts
@@ -20,6 +20,7 @@ const skinflux = new SKInflux(
     bucket: process.env.BUCKET || '!!!',
     org: process.env.ORG || '!!!',
     writeOptions: {},
+    filteringRules: [],
     ignoredPaths: [],
     ignoredSources: [],
     useSKTimestamp: false,


### PR DESCRIPTION
Add more flexible filteringRules so that you can use both allow and ignore logic in determining what should or should not be written to the database.

This allows also addressing specific (path, source) combinations, where ignoredPaths and ignoredSources operate indenpendently and you can not ignore specific path from a specific source.

<img width="981" alt="image" src="https://github.com/user-attachments/assets/45f2960a-1b10-4786-b358-b898449177e4">

Fixes #27.