### PR TITLE
feature: wait for InfluxDB to become available

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@signalk/server-api": "^2.3.0",
+    "@signalk/server-api": "^2.5.0",
     "@types/chai": "^4.3.3",
     "@types/express": "^4.17.17",
     "@types/mocha": "^9.1.1",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -143,7 +143,9 @@ export default function InfluxPluginFactory(app: App): Plugin & InfluxPlugin {
         onStop.push(() => clearInterval(interval))
       }
 
+      app.setPluginStatus(`Connecting ${skInfluxes.map((sk) => sk.url)}`)
       return Promise.all(skInfluxes.map((skInflux) => skInflux.init())).then(() => {
+        app.setPluginStatus('Connected')
         const onDelta = (_delta: Delta) => {
           const delta = _delta as ValuesDelta
           const now = Date.now()

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,7 +17,7 @@ import { SKInflux, SKInfluxConfig } from './influx'
 import { EventEmitter } from 'stream'
 import { getDailyLogData, registerHistoryApiRoute } from './HistoryAPI'
 import { IRouter } from 'express'
-import { Context, Delta, MetaDelta, Path, PathValue, SourceRef, ValuesDelta } from '@signalk/server-api'
+import { Context, Delta, hasValues, MetaDelta, Path, PathValue, SourceRef, ValuesDelta } from '@signalk/server-api'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageInfo = require('../package.json')
@@ -152,7 +152,7 @@ export default function InfluxPluginFactory(app: App): Plugin & InfluxPlugin {
           const isSelf = delta.context === selfContext
           delta.updates &&
             delta.updates.forEach((update) => {
-              update.values &&
+              hasValues(update) &&
                 update.values.forEach((pathValue) => {
                   skInfluxes.forEach((skInflux) =>
                     skInflux.handleValue(


### PR DESCRIPTION
On server/plugin start wait for Influx connection to become available.

Previously plugin startup would fail if InfluxDB is not available when plugin starts and never retry. If SK server would start more quickly than Influx on server bootup the plugin would never start writing data.

Fixes #52.