### PR TITLE
fix: make @signalk/server-api runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@signalk/server-api": "^2.5.0",
     "@types/chai": "^4.3.3",
     "@types/express": "^4.17.17",
     "@types/mocha": "^9.1.1",
@@ -51,6 +50,7 @@
     "@js-joda/timezone": "^2.12.1",
     "@signalk/freeboard-sk": "^2.4.0",
     "@signalk/signalk-schema": "^1.6.0",
+    "@signalk/server-api": "^2.5.0",
     "influx": "^5.9.3",
     "s2-geometry": "^1.2.10"
   },


### PR DESCRIPTION
We are now actually using code from the server api, so it needs to be an actual dependency, not just a devDependency.

Fixes #74.