### PR TITLE
feature: HistoryApi - exclude rows with all null values

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/baconjs": "^0.7.34",
     "@types/chai": "^4.3.3",
     "@types/express": "^4.17.17",
     "@types/mocha": "^9.1.1",
@@ -49,8 +50,8 @@
     "@js-joda/core": "^5.3.0",
     "@js-joda/timezone": "^2.12.1",
     "@signalk/freeboard-sk": "^2.4.0",
-    "@signalk/signalk-schema": "^1.6.0",
     "@signalk/server-api": "^2.5.0",
+    "@signalk/signalk-schema": "^1.6.0",
     "influx": "^5.9.3",
     "s2-geometry": "^1.2.10"
   },


### PR DESCRIPTION
Previously the InfluxQL result included a row for
each time bucket (specified by group by).

This changes the behavior so that only rows with
some non null values are returned.

For queries that target either only numeric or
only nav.position values the InfluxQL query uses
fill(none) to return only values with data.

For queries that include both types of data
the separately run queries' results need to
be collated and filtered for some non null
values on each row, so we can't use fill(none).