### PR TITLE
Feature: set default number of points to 1000

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -154,7 +154,7 @@ export function getValues(
   const timeResolutionMillis =
     (req.query.resolution
       ? Number.parseFloat(req.query.resolution as string)
-      : (to.toEpochSecond() - from.toEpochSecond()) / 500) * 1000
+      : (to.toEpochSecond() - from.toEpochSecond()) / 1000) * 1000
   const pathExpressions = ((req.query.paths as string) || '').replace(/[^0-9a-z.,:]/gi, '').split(',')
   const pathSpecs: PathSpec[] = pathExpressions.map(splitPathExpression)
 


### PR DESCRIPTION
Bump the default number of points returned via History API to 1000, as 500 seems a bit too coarse. Clients can override resolution as they see fit.