### PR TITLE
Fix: support slash in bucket name

### DIFF
--- a/src/HistoryAPI.ts
+++ b/src/HistoryAPI.ts
@@ -2,7 +2,6 @@ import { DateTimeFormatter, LocalDate, ZoneId, ZonedDateTime } from '@js-joda/co
 
 import { SKInflux } from './influx'
 import { InfluxDB as InfluxV1 } from 'influx'
-import { FluxResultObserver, FluxTableMetaData } from '@influxdata/influxdb-client'
 import { Context, Path, Timestamp } from '@signalk/server-api'
 import {
   AggregateMethod,
@@ -346,20 +345,6 @@ function applyMovingAveragePostProcessing(
   }
 }
 
-interface ValuesResult {
-  context: string
-  range: {
-    from: string
-    to: string
-  }
-  values: {
-    path: string
-    method: string
-    source?: string
-  }[]
-  data: ValuesResultRow[]
-}
-
 interface SimpleResponse {
   status: (s: number) => void
   /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
@@ -375,9 +360,6 @@ interface SimpleRequest {
     format?: string
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ValuesResultRow = any[]
 
 export function getPositions(
   v1Client: InfluxV1,
@@ -642,108 +624,6 @@ function getNumericValues(
       data: resultData as DataRow[],
     }
   })
-}
-
-export async function getValuesFlux(
-  influx: SKInflux,
-  context: string,
-  from: ZonedDateTime,
-  to: ZonedDateTime,
-  debug: (s: string) => void,
-  req: SimpleRequest,
-  res: SimpleResponse,
-): Promise<ValuesResult | void> {
-  const timeResolutionMillis =
-    (req.query.resolution
-      ? Number.parseFloat(req.query.resolution as string)
-      : (to.toEpochSecond() - from.toEpochSecond()) / 500) * 1000
-
-  const pathExpressions = ((req.query.paths as string) || '').replace(/[^0-9a-z.,:]/gi, '').split(',')
-  const pathSpecs: PathSpec[] = pathExpressions.map(splitPathExpression)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const resultData: any[] = []
-
-  const measurements = pathSpecs
-    .map(
-      ({ path, aggregateFunction, queryResultName }, i) => `
-  dataForContext
-  |> filter(fn: (r) => r._measurement == "${path}")
-  |> aggregateWindow(every: ${timeResolutionMillis.toFixed(0)}ms, fn: ${aggregateFunction})
-  |> yield(name: "${queryResultName + i}")
-  `,
-    )
-    .join('\n')
-  let query = `
-    dataForContext = from(bucket: "${influx.bucket}")
-    |> range(start: ${from.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}Z, stop: ${to.format(
-    DateTimeFormatter.ISO_LOCAL_DATE_TIME,
-  )}Z)
-    |> filter(fn: (r) => r.context == "${context}")
-
-    ${measurements}
-    `
-
-  if (pathSpecs[0].path === 'navigation.position') {
-    query = `
-    from(bucket: "${influx.bucket}")
-    |> range(start: ${from.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)}Z, stop: ${to.format(
-      DateTimeFormatter.ISO_LOCAL_DATE_TIME,
-    )}Z)
-    |> filter(fn: (r) =>
-      r.context == "${context}" and
-      r._measurement == "navigation.position" and (r._field == "lat" or r._field == "lon") )
-    |> aggregateWindow(every: ${timeResolutionMillis.toFixed(0)}ms, fn: first)
-    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
-    |> keep(columns: ["_time", "lat", "lon"])
-    |> sort(columns:["_time"])
-    `
-  }
-  debug(query)
-
-  const queryResultNames = pathSpecs.map(({ queryResultName }, i) => `${queryResultName + i}`)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const resultTimes: Record<any, number> = {}
-  let i = 0
-  let j = 0
-
-  const start = Date.now()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const o: FluxResultObserver<any> = {
-    next: (row: string[], tableMeta: FluxTableMetaData) => {
-      if (j++ === 0) {
-        debug(`start  ${Date.now() - start}`)
-      }
-      const time = tableMeta.get(row, '_time')
-      if (resultTimes[time] === undefined) {
-        resultTimes[time] = i++
-        resultData.push([time])
-      }
-      const result = tableMeta.get(row, 'result')
-      const value = tableMeta.get(row, '_value')
-      const fieldIndex = queryResultNames.indexOf(result)
-      resultData[resultTimes[time]][fieldIndex + 1] = value
-      return true
-    },
-    error: (s: Error) => {
-      console.error(s.message)
-      console.error(query)
-      res.status(500)
-      res.json(s)
-    },
-    complete: () => {
-      debug(`complete ${Date.now() - start}`)
-      res.json({
-        context,
-        range: {
-          from: from.toString() as Timestamp,
-          to: to.toString() as Timestamp,
-        },
-        values: pathSpecs.map(({ path, aggregateMethod }: PathSpec) => ({ path, method: aggregateMethod })),
-        data: resultData,
-      })
-    },
-  }
-  influx.queryApi.queryRows(query, o)
 }
 
 interface PathSpec {

--- a/src/influx.test.ts
+++ b/src/influx.test.ts
@@ -1,5 +1,21 @@
 import { expect } from 'chai'
-import { SKInflux, SKInfluxConfig } from './influx'
+import { SKInflux, SKInfluxConfig, bucketToV1DatabaseName } from './influx'
+
+describe('bucketToV1DatabaseName', () => {
+  it('should replace forward slashes with underscores', () => {
+    expect(bucketToV1DatabaseName('my/bucket')).to.equal('my_bucket')
+    expect(bucketToV1DatabaseName('a/b/c')).to.equal('a_b_c')
+  })
+
+  it('should replace backslashes with underscores', () => {
+    expect(bucketToV1DatabaseName('my\\bucket')).to.equal('my_bucket')
+  })
+
+  it('should leave names without slashes unchanged', () => {
+    expect(bucketToV1DatabaseName('my_bucket')).to.equal('my_bucket')
+    expect(bucketToV1DatabaseName('simple')).to.equal('simple')
+  })
+})
 
 describe('ignoreStatusByRule', () => {
   const noopLogging = {

--- a/src/influx.ts
+++ b/src/influx.ts
@@ -116,6 +116,12 @@ type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 export const influxPath = (path: string) => (path !== '' ? path : '<empty>')
 
+/**
+ * Sanitize a bucket name for use as an InfluxDB v1 compatibility database name.
+ * InfluxDB v1 database names do not support forward slashes or backslashes.
+ */
+export const bucketToV1DatabaseName = (bucket: string) => bucket.replace(/[/\\]/g, '_')
+
 enum JsValueType {
   number = 'number',
   string = 'string',
@@ -131,6 +137,7 @@ export class SKInflux {
   private influx: InfluxDB
   public org: string
   public bucket: string
+  public v1DatabaseName: string
   private writeApi: WriteApi
   public queryApi: QueryApi
   public writtenLinesCount = 0
@@ -162,6 +169,7 @@ export class SKInflux {
     this.influx = new InfluxDB(config)
     this.org = org
     this.bucket = bucket
+    this.v1DatabaseName = bucketToV1DatabaseName(bucket)
     this.url = url
     this.onlySelf = onlySelf
     this.ignoredPaths = ignoredPaths
@@ -192,7 +200,7 @@ export class SKInflux {
       password: '',
       port: Number(parsedUrl.port),
       protocol: <'http' | 'https'>parsedUrl.protocol.slice(0, -1),
-      database: bucket,
+      database: this.v1DatabaseName,
       options: {
         headers: {
           Authorization: `Token ${config.token}`,
@@ -233,11 +241,11 @@ export class SKInflux {
       throw new Error('Error retrieving dbrs')
     }
     //is there mapping where v1 database name is the same as bucket
-    if (!dbrs.content.find((dbr) => dbr.database === this.bucket)) {
+    if (!dbrs.content.find((dbr) => dbr.database === this.v1DatabaseName)) {
       await dbrsApi.postDBRP({
         body: {
           org: this.org,
-          database: this.bucket,
+          database: this.v1DatabaseName,
           bucketID: bucketId,
           retention_policy: 'default',
           default: true,

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'stream'
 import InfluxPluginFactory, { App, InfluxPlugin, Plugin } from './plugin'
 import waitOn from 'wait-on'
 import retry from 'async-await-retry'
-import { influxPath } from './influx'
+import { influxPath, bucketToV1DatabaseName } from './influx'
 import { Context, Path, PathValue } from '@signalk/server-api'
 import { getValues, InfluxHistoryProvider } from './HistoryAPI'
 import { ZoneId, ZonedDateTime } from '@js-joda/core'
@@ -1217,6 +1217,85 @@ describe('Plugin', () => {
       // Context in response should be the actual self context, not 'vessels.self'
       expect(result.context).to.equal(TESTCONTEXT)
       expect(result.data.length).to.be.greaterThan(0)
+    })
+  })
+
+  describe('Bucket name with forward slash', () => {
+    let slashBucket: string
+    let slashPlugin: Plugin & InfluxPlugin
+
+    beforeEach(async () => {
+      slashBucket = `test/bucket/${Date.now()}`
+      slashPlugin = InfluxPluginFactory(app)
+      await slashPlugin.start({
+        influxes: [
+          {
+            url: `http://${INFLUX_HOST}:8086`,
+            token: 'signalk_token',
+            org: 'signalk_org',
+            bucket: slashBucket,
+            onlySelf: false,
+            writeOptions: {
+              batchSize: 1,
+              flushInterval: 10,
+              maxRetries: 1,
+            },
+            filteringRules: [],
+            ignoredPaths: [],
+            ignoredSources: [],
+            useSKTimestamp: false,
+            resolution: 0,
+          },
+        ],
+        outputDailyLog: false,
+      })
+    })
+
+    afterEach(() => {
+      slashPlugin.stop()
+    })
+
+    it('writes and reads data with forward slash in bucket name', async () => {
+      app.signalk.emit('delta', {
+        context: TESTCONTEXT,
+        updates: [
+          {
+            $source: TESTSOURCE,
+            timestamp: new Date('2022-08-17T17:01:00Z'),
+            values: [
+              {
+                path: TESTPATHNUMERIC,
+                value: TESTNUMERICVALUE,
+              },
+            ],
+          },
+        ],
+      })
+
+      return retry(
+        () =>
+          slashPlugin.flush().then(() =>
+            slashPlugin
+              .getSelfValues({
+                paths: [TESTPATHNUMERIC],
+                influxIndex: 0,
+              })
+              .then((rows) => {
+                expect(rows.length).to.equal(1)
+              }),
+          ),
+        [null],
+        {
+          retriesMax: 5,
+          interval: 50,
+        },
+      )
+    })
+
+    it('uses sanitized v1 database name', () => {
+      const influx = slashPlugin.skInfluxes()[0]
+      expect(influx.v1DatabaseName).to.equal(bucketToV1DatabaseName(slashBucket))
+      expect(influx.v1DatabaseName).to.not.include('/')
     })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "typeRoots": ["./src", "./node_modules/@types"],
     "target": "ES2022",
     "lib": [


### PR DESCRIPTION
Use InfluxDB v1 compatible name when querying
to extend support to buckets with forward slash
in their name.

Fixes https://github.com/tkurki/signalk-to-influxdb2/issues/109.