### PR TITLE
fix: increase the query timeout

### DIFF
--- a/src/influx.ts
+++ b/src/influx.ts
@@ -194,6 +194,7 @@ export class SKInflux {
       protocol: <'http' | 'https'>parsedUrl.protocol.slice(0, -1),
       database: bucket,
       options: {
+        timeout: 90000,
         headers: {
           Authorization: `Token ${config.token}`,
         },


### PR DESCRIPTION
when querying long tracks with decent granularity the 30s default query timeout is easily overrun. increase the timeout to 90s which allows querying bigger tracks.