### PR TITLE
fix: NaN numbers throwing errors

### DIFF
--- a/src/influx.ts
+++ b/src/influx.ts
@@ -419,6 +419,9 @@ export class SKInflux {
       try {
         switch (valueType) {
           case JsValueType.number:
+            if (typeof value !== 'number' || Number.isNaN(value)) {
+              return []
+            }
             point.floatField('value', value)
             break
           case JsValueType.string:


### PR DESCRIPTION
```
Jul 15 12:40:18 2026-07-15T12:40:18.090Z signalk-to-influxdb2 Error creating point navigation.position.dgpsAge:NaN => number
Jul 15 12:40:19 2026-07-15T12:40:19.091Z signalk-to-influxdb2 Error creating point navigation.position.dgpsAge:NaN => number
Jul 15 12:40:19 2026-07-15T12:40:19.506Z signalk-to-influxdb2 Error creating point electrical.chargers.orion.output.voltage:NaN => number
```