### PR TITLE
Expand empty-path object values instead of storing them under "<empty>"

### DIFF
--- a/src/influx.test.ts
+++ b/src/influx.test.ts
@@ -112,3 +112,73 @@ describe('ignoreStatusByRule', () => {
     expect(influx.ignoreStatusByRule('steering.rudderAngle', 'C')).to.equal(true)
   })
 })
+
+describe('handleValue with an empty/undefined-path object value', () => {
+  const noopLogging = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    debug: (...args: any) => {
+      return
+    },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    error: (...args: any) => {
+      return
+    },
+  }
+
+  const config: SKInfluxConfig = {
+    url: 'http://127.0.0.1:8086',
+    token: 'test_token',
+    org: 'test_org',
+    bucket: 'test_bucket',
+    onlySelf: false,
+    filteringRules: [],
+    ignoredPaths: [],
+    ignoredSources: [],
+    useSKTimestamp: false,
+    resolution: 0,
+    writeOptions: {},
+  }
+
+  it('should not throw on an empty-path object value (e.g. AIS static data)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const influx = new SKInflux(config, noopLogging, () => {})
+    expect(() =>
+      influx.handleValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        'vessels.urn:mrn:imo:mmsi:338316896' as any,
+        false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        'ydg-nmea-2000' as any,
+        undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { path: '', value: { name: 'INSANITY' } } as any,
+        Date.now(),
+      ),
+    ).to.not.throw()
+  })
+
+  it('should expand an empty-path object value into one point per key, not "<empty>"', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    const influx = new SKInflux(config, noopLogging, () => {})
+    const processedPaths: (string | undefined)[] = []
+    // Capture which paths actually reach toPoints (i.e. get stored). The fix
+    // should expand { path: '', value: { name, mmsi } } into name + mmsi.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(influx as any).toPoints = (_c: any, _s: any, _src: any, _t: any, pv: any) => {
+      processedPaths.push(pv.path)
+      return []
+    }
+    influx.handleValue(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      'vessels.urn:mrn:imo:mmsi:368327340' as any,
+      true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      'defaults' as any,
+      undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { path: '', value: { name: 'Tideye', mmsi: '368327340' } } as any,
+      Date.now(),
+    )
+    expect(processedPaths).to.have.members(['name', 'mmsi'])
+  })
+})

--- a/src/influx.ts
+++ b/src/influx.ts
@@ -264,6 +264,21 @@ export class SKInflux {
     pathValue: PathValue,
     now: number,
   ) {
+    // Signalk sets several top-level vessel properties at once with an
+    // empty/undefined path and an object value — e.g. AIS static data arrives as
+    // { path: '', value: { name, mmsi } }. Expand it so each key becomes its own
+    // path (and Influx measurement), instead of dumping the whole object as a
+    // JSON blob under the "<empty>" measurement (and crashing typeFor() on an
+    // undefined path via pathValue.path.startsWith()).
+    if (pathValue.path == null || (pathValue.path as string) === '') {
+      const objectValue = pathValue.value
+      if (objectValue != null && typeof objectValue === 'object' && !Array.isArray(objectValue)) {
+        Object.entries(objectValue).forEach(([key, value]) =>
+          this.handleValue(context, isSelf, sourceRef, timestamp, { path: key as Path, value } as PathValue, now),
+        )
+      }
+      return
+    }
     if (this.isIgnored(pathValue.path, sourceRef)) {
       return
     }


### PR DESCRIPTION
## Problem
Signalk sets several top-level vessel properties at once with an **empty path** and an **object value** — e.g. AIS static data arrives as `{ path: "", value: { name, mmsi } }`. The plugin:

1. builds the measurement name from `influxPath("")` which returns the literal string `<empty>` (influx.ts:117), and
2. hits the `object` branch of `toPoints`, JSON-stringifying the whole object into a single `value` field.

So vessel/aton names and MMSIs are stored as JSON blobs (`{"name":"INSANITY"}`, `{"mmsi":"..."}`) under one measurement literally named `<empty>`, keyed only by context — unqueryable and a huge source of point bloat (millions of these on a vessel receiving AIS). When the path is `undefined` rather than `""`, `typeFor()` → `_typeFor()` also throws `Cannot read properties of undefined (reading 'startsWith')`.

## Fix
When a delta value has an empty/undefined path and an object value, **expand it** — recurse so each key becomes its own path (and therefore its own measurement). `{ path: "", value: { name, mmsi } }` becomes a `name` series and a `mmsi` series per context, instead of an `<empty>` JSON blob. Non-object empty-path values (which can't be stored meaningfully) are skipped.

## Tests
- no throw on an empty-path object value;
- an empty-path object value expands into one point per key.

Verified on a live vessel receiving heavy AIS: zero `startsWith` errors, the `<empty>` measurement stops growing, and vessel names now land in a clean queryable `name` series (`BOW PRECISION`, `DOUBLE H`, …).